### PR TITLE
fix: add debug logging to silent error paths

### DIFF
--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
+import type { PluginPackageChannel } from "../plugins/manifest.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("bundled-channel-catalog");
+
+type ChannelCatalogEntryLike = {
+  openclaw?: {
+    channel?: PluginPackageChannel;
+  };
+};
+
+export type BundledChannelCatalogEntry = {
+  id: string;
+  channel: PluginPackageChannel;
+  aliases: readonly string[];
+  order: number;
+};
+
+const OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH = path.join("dist", "channel-catalog.json");
+
+function listPackageRoots(): string[] {
+  return [
+    resolveOpenClawPackageRootSync({ cwd: process.cwd() }),
+    resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url }),
+  ].filter((entry, index, all): entry is string => Boolean(entry) && all.indexOf(entry) === index);
+}
+
+function listBundledExtensionPackageJsonPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  // Delegate to the plugin loader's resolver so channel metadata stays in lock
+  // step with whichever bundled plugin tree is actually loaded at runtime
+  // (source extensions/ in dev/test, dist/extensions in published installs,
+  // dist-runtime/extensions when paired with dist, etc.). See
+  // src/plugins/bundled-dir.ts for the full candidate-order policy and
+  // src/plugins/bundled-dir.test.ts for the precedence coverage. Reusing the
+  // resolver also picks up OPENCLAW_BUNDLED_PLUGINS_DIR overrides and the
+  // bun --compile sibling layout for free.
+  const extensionsRoot = resolveBundledPluginsDir(env);
+  if (!extensionsRoot) {
+    return [];
+  }
+  try {
+    return fs
+      .readdirSync(extensionsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(extensionsRoot, entry.name, "package.json"))
+      .filter((entry) => fs.existsSync(entry));
+  } catch {
+    return [];
+  }
+}
+
+function readBundledExtensionCatalogEntriesSync(): ChannelCatalogEntryLike[] {
+  const entries: ChannelCatalogEntryLike[] = [];
+  for (const packageJsonPath of listBundledExtensionPackageJsonPaths()) {
+    try {
+      const payload = JSON.parse(
+        fs.readFileSync(packageJsonPath, "utf8"),
+      ) as ChannelCatalogEntryLike;
+      entries.push(payload);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+function readOfficialCatalogFileSync(): ChannelCatalogEntryLike[] {
+  for (const packageRoot of listPackageRoots()) {
+    const candidate = path.join(packageRoot, OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH);
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    try {
+      const payload = JSON.parse(fs.readFileSync(candidate, "utf8")) as {
+        entries?: unknown;
+      };
+      return Array.isArray(payload.entries) ? (payload.entries as ChannelCatalogEntryLike[]) : [];
+    } catch (err) {
+      log.warn(`failed to read channel catalog ${candidate}: ${err}`);
+      continue;
+    }
+  }
+  return [];
+}
+
+function toBundledChannelEntry(entry: ChannelCatalogEntryLike): BundledChannelCatalogEntry | null {
+  const channel = entry.openclaw?.channel;
+  const id = normalizeOptionalLowercaseString(channel?.id);
+  if (!id || !channel) {
+    return null;
+  }
+  const aliases = Array.isArray(channel.aliases)
+    ? channel.aliases
+        .map((alias) => normalizeOptionalLowercaseString(alias))
+        .filter((alias): alias is string => Boolean(alias))
+    : [];
+  const order =
+    typeof channel.order === "number" && Number.isFinite(channel.order)
+      ? channel.order
+      : Number.MAX_SAFE_INTEGER;
+  return {
+    id,
+    channel,
+    aliases,
+    order,
+  };
+}
+
+export function listBundledChannelCatalogEntries(): BundledChannelCatalogEntry[] {
+  const bundledEntries = readBundledExtensionCatalogEntriesSync()
+    .map((entry) => toBundledChannelEntry(entry))
+    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry));
+  if (bundledEntries.length > 0) {
+    return bundledEntries;
+  }
+  return readOfficialCatalogFileSync()
+    .map((entry) => toBundledChannelEntry(entry))
+    .filter((entry): entry is BundledChannelCatalogEntry => Boolean(entry));
+}

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -1,0 +1,253 @@
+/**
+ * Gmail Watcher Service
+ *
+ * Automatically starts `gog gmail watch serve` when the gateway starts,
+ * if hooks.gmail is configured with an account.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { hasBinary } from "../agents/skills.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { ensureTailscaleEndpoint } from "./gmail-setup-utils.js";
+import { isAddressInUseError } from "./gmail-watcher-errors.js";
+import {
+  buildGogWatchServeLogArgs,
+  buildGogWatchServeArgs,
+  buildGogWatchStartArgs,
+  type GmailHookRuntimeConfig,
+  resolveGmailHookRuntimeConfig,
+} from "./gmail.js";
+
+const log = createSubsystemLogger("gmail-watcher");
+
+let watcherProcess: ChildProcess | null = null;
+let renewInterval: ReturnType<typeof setInterval> | null = null;
+let shuttingDown = false;
+let currentConfig: GmailHookRuntimeConfig | null = null;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Check if gog binary is available
+ */
+function isGogAvailable(): boolean {
+  return hasBinary("gog");
+}
+
+/**
+ * Start the Gmail watch (registers with Gmail API)
+ */
+async function startGmailWatch(
+  cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
+): Promise<boolean> {
+  const args = ["gog", ...buildGogWatchStartArgs(cfg)];
+  try {
+    const result = await runCommandWithTimeout(args, { timeoutMs: 120_000 });
+    if (result.code !== 0) {
+      const message = result.stderr || result.stdout || "gog watch start failed";
+      log.error(`watch start failed: ${message}`);
+      return false;
+    }
+    log.info(`watch started for ${cfg.account}`);
+    return true;
+  } catch (err) {
+    log.error(`watch start error: ${String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * Spawn the gog gmail watch serve process
+ */
+function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
+  const args = buildGogWatchServeArgs(cfg);
+  log.info(`starting gog ${buildGogWatchServeLogArgs(cfg).join(" ")}`);
+  let addressInUse = false;
+
+  const child = spawn("gog", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+  });
+
+  child.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) {
+      log.info(`[gog] ${line}`);
+    }
+  });
+
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (!line) {
+      return;
+    }
+    if (isAddressInUseError(line)) {
+      addressInUse = true;
+    }
+    log.warn(`[gog] ${line}`);
+  });
+
+  child.on("error", (err) => {
+    log.error(`gog process error: ${String(err)}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (shuttingDown) {
+      return;
+    }
+    if (addressInUse) {
+      log.warn(
+        "gog serve failed to bind (address already in use); stopping restarts. " +
+          "Another watcher is likely running. Set OPENCLAW_SKIP_GMAIL_WATCHER=1 or stop the other process.",
+      );
+      watcherProcess = null;
+      return;
+    }
+    log.warn(`gog exited (code=${code}, signal=${signal}); restarting in 5s`);
+    watcherProcess = null;
+    // Clear any previous restart timer before setting a new one
+    if (restartTimer !== null) {
+      clearTimeout(restartTimer);
+    }
+    restartTimer = setTimeout(() => {
+      restartTimer = null;
+      if (shuttingDown || !currentConfig) {
+        return;
+      }
+      watcherProcess = spawnGogServe(currentConfig);
+    }, 5000);
+  });
+
+  return child;
+}
+
+export type GmailWatcherStartResult = {
+  started: boolean;
+  reason?: string;
+};
+
+/**
+ * Start the Gmail watcher service.
+ * Called automatically by the gateway if hooks.gmail is configured.
+ */
+export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatcherStartResult> {
+  // Check if gmail hooks are configured
+  if (!cfg.hooks?.enabled) {
+    return { started: false, reason: "hooks not enabled" };
+  }
+
+  if (!cfg.hooks?.gmail?.account) {
+    return { started: false, reason: "no gmail account configured" };
+  }
+
+  // Check if gog is available
+  const gogAvailable = isGogAvailable();
+  if (!gogAvailable) {
+    return { started: false, reason: "gog binary not found" };
+  }
+
+  // Resolve the full runtime config
+  const resolved = resolveGmailHookRuntimeConfig(cfg, {});
+  if (!resolved.ok) {
+    return { started: false, reason: resolved.error };
+  }
+
+  const runtimeConfig = resolved.value;
+  currentConfig = runtimeConfig;
+
+  // Set up Tailscale endpoint if needed
+  if (runtimeConfig.tailscale.mode !== "off") {
+    try {
+      await ensureTailscaleEndpoint({
+        mode: runtimeConfig.tailscale.mode,
+        path: runtimeConfig.tailscale.path,
+        port: runtimeConfig.serve.port,
+        target: runtimeConfig.tailscale.target,
+      });
+      log.info(
+        `tailscale ${runtimeConfig.tailscale.mode} configured for port ${runtimeConfig.serve.port}`,
+      );
+    } catch (err) {
+      log.error(`tailscale setup failed: ${String(err)}`);
+      return {
+        started: false,
+        reason: `tailscale setup failed: ${String(err)}`,
+      };
+    }
+  }
+
+  // Start the Gmail watch (register with Gmail API)
+  const watchStarted = await startGmailWatch(runtimeConfig);
+  if (!watchStarted) {
+    log.warn("gmail watch start failed, but continuing with serve");
+  }
+
+  // Spawn the gog serve process
+  shuttingDown = false;
+  watcherProcess = spawnGogServe(runtimeConfig);
+
+  // Set up renewal interval
+  const renewMs = runtimeConfig.renewEveryMinutes * 60_000;
+  renewInterval = setInterval(() => {
+    if (shuttingDown) {
+      return;
+    }
+    void startGmailWatch(runtimeConfig);
+  }, renewMs);
+
+  log.info(
+    `gmail watcher started for ${runtimeConfig.account} (renew every ${runtimeConfig.renewEveryMinutes}m)`,
+  );
+
+  return { started: true };
+}
+
+/**
+ * Stop the Gmail watcher service.
+ */
+export async function stopGmailWatcher(): Promise<void> {
+  shuttingDown = true;
+
+  if (renewInterval) {
+    clearInterval(renewInterval);
+    renewInterval = null;
+  }
+
+  if (restartTimer !== null) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
+  if (watcherProcess) {
+    log.info("stopping gmail watcher");
+    watcherProcess.kill("SIGTERM");
+
+    // Wait a bit for graceful shutdown
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        if (watcherProcess) {
+          watcherProcess.kill("SIGKILL");
+        }
+        resolve();
+      }, 3000);
+
+      watcherProcess?.on("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    watcherProcess = null;
+  }
+
+  currentConfig = null;
+  log.info("gmail watcher stopped");
+}
+
+/**
+ * Check if the Gmail watcher is running.
+ */
+export function isGmailWatcherRunning(): boolean {
+  return watcherProcess !== null && !shuttingDown;
+}

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -1,0 +1,288 @@
+import path from "node:path";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  fetchWithSsrFGuard,
+  withStrictGuardedFetchMode,
+  withTrustedExplicitProxyGuardedFetchMode,
+} from "../infra/net/fetch-guard.js";
+import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { redactSensitiveText } from "../logging/redact.js";
+import { detectMime, extensionForMime } from "./mime.js";
+import { readResponseTextSnippet, readResponseWithLimit } from "./read-response-with-limit.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("media-fetch");
+
+type FetchMediaResult = {
+  buffer: Buffer;
+  contentType?: string;
+  fileName?: string;
+};
+
+export type MediaFetchErrorCode = "max_bytes" | "http_error" | "fetch_failed";
+
+export class MediaFetchError extends Error {
+  readonly code: MediaFetchErrorCode;
+
+  constructor(code: MediaFetchErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.code = code;
+    this.name = "MediaFetchError";
+  }
+}
+
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type FetchDispatcherAttempt = {
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  lookupFn?: LookupFn;
+};
+
+type FetchMediaOptions = {
+  url: string;
+  fetchImpl?: FetchLike;
+  requestInit?: RequestInit;
+  filePathHint?: string;
+  maxBytes?: number;
+  maxRedirects?: number;
+  /** Abort if the response body stops yielding data for this long (ms). */
+  readIdleTimeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
+  lookupFn?: LookupFn;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  dispatcherAttempts?: FetchDispatcherAttempt[];
+  shouldRetryFetchError?: (error: unknown) => boolean;
+  /**
+   * Allow an operator-configured explicit proxy to resolve target DNS after
+   * hostname-policy checks instead of forcing local pinned-DNS first.
+   */
+  trustExplicitProxyDns?: boolean;
+};
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/g, "");
+}
+
+function parseContentDispositionFileName(header?: string | null): string | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
+  if (starMatch?.[1]) {
+    const cleaned = stripQuotes(starMatch[1].trim());
+    const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
+    try {
+      return path.basename(decodeURIComponent(encoded));
+    } catch {
+      return path.basename(encoded);
+    }
+  }
+  const match = /filename\s*=\s*([^;]+)/i.exec(header);
+  if (match?.[1]) {
+    return path.basename(stripQuotes(match[1].trim()));
+  }
+  return undefined;
+}
+
+async function readErrorBodySnippet(
+  res: Response,
+  opts?: {
+    maxChars?: number;
+    chunkTimeoutMs?: number;
+  },
+): Promise<string | undefined> {
+  try {
+    return await readResponseTextSnippet(res, {
+      maxBytes: 8 * 1024,
+      maxChars: opts?.maxChars,
+      chunkTimeoutMs: opts?.chunkTimeoutMs,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function redactMediaUrl(url: string): string {
+  return redactSensitiveText(url);
+}
+
+export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<FetchMediaResult> {
+  const {
+    url,
+    fetchImpl,
+    requestInit,
+    filePathHint,
+    maxBytes,
+    maxRedirects,
+    readIdleTimeoutMs,
+    ssrfPolicy,
+    lookupFn,
+    dispatcherPolicy,
+    dispatcherAttempts,
+    shouldRetryFetchError,
+    trustExplicitProxyDns,
+  } = options;
+  const sourceUrl = redactMediaUrl(url);
+
+  let res: Response;
+  let finalUrl = url;
+  let release: (() => Promise<void>) | null = null;
+  const attempts =
+    dispatcherAttempts && dispatcherAttempts.length > 0
+      ? dispatcherAttempts
+      : [{ dispatcherPolicy, lookupFn }];
+  const runGuardedFetch = async (attempt: FetchDispatcherAttempt) =>
+    await fetchWithSsrFGuard(
+      (trustExplicitProxyDns && attempt.dispatcherPolicy?.mode === "explicit-proxy"
+        ? withTrustedExplicitProxyGuardedFetchMode
+        : withStrictGuardedFetchMode)({
+        url,
+        fetchImpl,
+        init: requestInit,
+        maxRedirects,
+        policy: ssrfPolicy,
+        lookupFn: attempt.lookupFn ?? lookupFn,
+        dispatcherPolicy: attempt.dispatcherPolicy,
+      }),
+    );
+  try {
+    let result!: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
+    const attemptErrors: unknown[] = [];
+    for (let i = 0; i < attempts.length; i += 1) {
+      try {
+        result = await runGuardedFetch(attempts[i]);
+        break;
+      } catch (err) {
+        if (
+          typeof shouldRetryFetchError !== "function" ||
+          !shouldRetryFetchError(err) ||
+          i === attempts.length - 1
+        ) {
+          if (attemptErrors.length > 0) {
+            const combined = new Error(
+              `Primary fetch failed and fallback fetch also failed for ${sourceUrl}`,
+              { cause: err },
+            );
+            (
+              combined as Error & {
+                primaryError?: unknown;
+                attemptErrors?: unknown[];
+              }
+            ).primaryError = attemptErrors[0];
+            (combined as Error & { attemptErrors?: unknown[] }).attemptErrors = [
+              ...attemptErrors,
+              err,
+            ];
+            throw combined;
+          }
+          throw err;
+        }
+        attemptErrors.push(err);
+        if (attemptErrors.length <= 2) {
+          log.debug(`fetch attempt ${i + 1} failed for ${sourceUrl}: ${err}`);
+        }
+      }
+    }
+    res = result.response;
+    finalUrl = result.finalUrl;
+    release = result.release;
+  } catch (err) {
+    throw new MediaFetchError(
+      "fetch_failed",
+      `Failed to fetch media from ${sourceUrl}: ${formatErrorMessage(err)}`,
+      {
+        cause: err,
+      },
+    );
+  }
+
+  try {
+    if (!res.ok) {
+      const statusText = res.statusText ? ` ${res.statusText}` : "";
+      const redirected = finalUrl !== url ? ` (redirected to ${redactMediaUrl(finalUrl)})` : "";
+      let detail = `HTTP ${res.status}${statusText}`;
+      if (!res.body) {
+        detail = `HTTP ${res.status}${statusText}; empty response body`;
+      } else {
+        const snippet = await readErrorBodySnippet(res, { chunkTimeoutMs: readIdleTimeoutMs });
+        if (snippet) {
+          detail += `; body: ${snippet}`;
+        }
+      }
+      throw new MediaFetchError(
+        "http_error",
+        `Failed to fetch media from ${sourceUrl}${redirected}: ${redactSensitiveText(detail)}`,
+      );
+    }
+
+    const contentLength = res.headers.get("content-length");
+    if (maxBytes && contentLength) {
+      const length = Number(contentLength);
+      if (Number.isFinite(length) && length > maxBytes) {
+        throw new MediaFetchError(
+          "max_bytes",
+          `Failed to fetch media from ${sourceUrl}: content length ${length} exceeds maxBytes ${maxBytes}`,
+        );
+      }
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = maxBytes
+        ? await readResponseWithLimit(res, maxBytes, {
+            onOverflow: ({ maxBytes, res }) =>
+              new MediaFetchError(
+                "max_bytes",
+                `Failed to fetch media from ${redactMediaUrl(res.url || url)}: payload exceeds maxBytes ${maxBytes}`,
+              ),
+            chunkTimeoutMs: readIdleTimeoutMs,
+          })
+        : Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      if (err instanceof MediaFetchError) {
+        throw err;
+      }
+      throw new MediaFetchError(
+        "fetch_failed",
+        `Failed to fetch media from ${redactMediaUrl(res.url || url)}: ${formatErrorMessage(err)}`,
+        { cause: err },
+      );
+    }
+    let fileNameFromUrl: string | undefined;
+    try {
+      const parsed = new URL(finalUrl);
+      const base = path.basename(parsed.pathname);
+      fileNameFromUrl = base || undefined;
+    } catch {
+      // ignore parse errors; leave undefined
+    }
+
+    const headerFileName = parseContentDispositionFileName(res.headers.get("content-disposition"));
+    let fileName =
+      headerFileName || fileNameFromUrl || (filePathHint ? path.basename(filePathHint) : undefined);
+
+    const filePathForMime =
+      headerFileName && path.extname(headerFileName) ? headerFileName : (filePathHint ?? finalUrl);
+    const contentType = await detectMime({
+      buffer,
+      headerMime: res.headers.get("content-type"),
+      filePath: filePathForMime,
+    });
+    if (fileName && !path.extname(fileName) && contentType) {
+      const ext = extensionForMime(contentType);
+      if (ext) {
+        fileName = `${fileName}${ext}`;
+      }
+    }
+
+    return {
+      buffer,
+      contentType: contentType ?? undefined,
+      fileName,
+    };
+  } finally {
+    if (release) {
+      await release();
+    }
+  }
+}

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -1,0 +1,685 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { runExec } from "../process/exec.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("image-ops");
+
+type Sharp = typeof import("sharp");
+type SharpFactory = (buffer: Buffer) => ReturnType<Sharp>;
+
+export type ImageMetadata = {
+  width: number;
+  height: number;
+};
+
+export const IMAGE_REDUCE_QUALITY_STEPS = [85, 75, 65, 55, 45, 35] as const;
+export const MAX_IMAGE_INPUT_PIXELS = 25_000_000;
+
+export function buildImageResizeSideGrid(maxSide: number, sideStart: number): number[] {
+  return [sideStart, 1800, 1600, 1400, 1200, 1000, 800]
+    .map((value) => Math.min(maxSide, value))
+    .filter((value, idx, arr) => value > 0 && arr.indexOf(value) === idx)
+    .toSorted((a, b) => b - a);
+}
+
+function isBun(): boolean {
+  return typeof (process.versions as { bun?: unknown }).bun === "string";
+}
+
+function prefersSips(): boolean {
+  return (
+    process.env.OPENCLAW_IMAGE_BACKEND === "sips" ||
+    (process.env.OPENCLAW_IMAGE_BACKEND !== "sharp" && isBun() && process.platform === "darwin")
+  );
+}
+
+let sharpFactoryPromise: Promise<SharpFactory> | null = null;
+
+async function loadSharp(): Promise<SharpFactory> {
+  sharpFactoryPromise ??= import("sharp").then((mod) => {
+    const sharp = (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp);
+    return (buffer: Buffer) =>
+      sharp(buffer, {
+        failOnError: false,
+        limitInputPixels: MAX_IMAGE_INPUT_PIXELS,
+      });
+  });
+  return sharpFactoryPromise;
+}
+
+function isPositiveImageDimension(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function buildImageMetadata(width: number, height: number): ImageMetadata | null {
+  if (!isPositiveImageDimension(width) || !isPositiveImageDimension(height)) {
+    return null;
+  }
+  return { width, height };
+}
+
+function readPngMetadata(buffer: Buffer): ImageMetadata | null {
+  if (buffer.length < 24) {
+    return null;
+  }
+  if (
+    buffer[0] !== 0x89 ||
+    buffer[1] !== 0x50 ||
+    buffer[2] !== 0x4e ||
+    buffer[3] !== 0x47 ||
+    buffer[4] !== 0x0d ||
+    buffer[5] !== 0x0a ||
+    buffer[6] !== 0x1a ||
+    buffer[7] !== 0x0a ||
+    buffer.toString("ascii", 12, 16) !== "IHDR"
+  ) {
+    return null;
+  }
+  return buildImageMetadata(buffer.readUInt32BE(16), buffer.readUInt32BE(20));
+}
+
+function readGifMetadata(buffer: Buffer): ImageMetadata | null {
+  if (buffer.length < 10) {
+    return null;
+  }
+  const signature = buffer.toString("ascii", 0, 6);
+  if (signature !== "GIF87a" && signature !== "GIF89a") {
+    return null;
+  }
+  return buildImageMetadata(buffer.readUInt16LE(6), buffer.readUInt16LE(8));
+}
+
+function readWebpMetadata(buffer: Buffer): ImageMetadata | null {
+  if (
+    buffer.length < 30 ||
+    buffer.toString("ascii", 0, 4) !== "RIFF" ||
+    buffer.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return null;
+  }
+  const chunkType = buffer.toString("ascii", 12, 16);
+  if (chunkType === "VP8X") {
+    if (buffer.length < 30) {
+      return null;
+    }
+    return buildImageMetadata(1 + buffer.readUIntLE(24, 3), 1 + buffer.readUIntLE(27, 3));
+  }
+  if (chunkType === "VP8 ") {
+    if (buffer.length < 30) {
+      return null;
+    }
+    return buildImageMetadata(buffer.readUInt16LE(26) & 0x3fff, buffer.readUInt16LE(28) & 0x3fff);
+  }
+  if (chunkType === "VP8L") {
+    if (buffer.length < 25 || buffer[20] !== 0x2f) {
+      return null;
+    }
+    const bits = buffer[21] | (buffer[22] << 8) | (buffer[23] << 16) | (buffer[24] << 24);
+    return buildImageMetadata((bits & 0x3fff) + 1, ((bits >> 14) & 0x3fff) + 1);
+  }
+  return null;
+}
+
+function readJpegMetadata(buffer: Buffer): ImageMetadata | null {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return null;
+  }
+
+  let offset = 2;
+  while (offset + 8 < buffer.length) {
+    while (offset < buffer.length && buffer[offset] === 0xff) {
+      offset++;
+    }
+    if (offset >= buffer.length) {
+      return null;
+    }
+
+    const marker = buffer[offset];
+    offset++;
+    if (marker === 0xd8 || marker === 0xd9) {
+      continue;
+    }
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      continue;
+    }
+    if (offset + 1 >= buffer.length) {
+      return null;
+    }
+
+    const segmentLength = buffer.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+      return null;
+    }
+
+    const isStartOfFrame =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isStartOfFrame) {
+      if (segmentLength < 7 || offset + 6 >= buffer.length) {
+        return null;
+      }
+      return buildImageMetadata(buffer.readUInt16BE(offset + 5), buffer.readUInt16BE(offset + 3));
+    }
+
+    offset += segmentLength;
+  }
+
+  return null;
+}
+
+function readImageMetadataFromHeader(buffer: Buffer): ImageMetadata | null {
+  return (
+    readPngMetadata(buffer) ??
+    readGifMetadata(buffer) ??
+    readWebpMetadata(buffer) ??
+    readJpegMetadata(buffer)
+  );
+}
+
+function countImagePixels(meta: ImageMetadata): number | null {
+  const pixels = meta.width * meta.height;
+  return Number.isSafeInteger(pixels) ? pixels : null;
+}
+
+function exceedsImagePixelLimit(meta: ImageMetadata): boolean {
+  return meta.width > Math.floor(MAX_IMAGE_INPUT_PIXELS / meta.height);
+}
+
+function createImagePixelLimitError(meta: ImageMetadata): Error {
+  const pixelCount = countImagePixels(meta);
+  const detail =
+    pixelCount === null
+      ? `${meta.width}x${meta.height}`
+      : `${meta.width}x${meta.height} (${pixelCount} pixels)`;
+  return new Error(
+    `Image dimensions exceed the ${MAX_IMAGE_INPUT_PIXELS.toLocaleString("en-US")} pixel input limit: ${detail}`,
+  );
+}
+
+function validateImagePixelLimit(meta: ImageMetadata): ImageMetadata {
+  if (exceedsImagePixelLimit(meta)) {
+    throw createImagePixelLimitError(meta);
+  }
+  return meta;
+}
+
+async function readImageMetadataForLimit(buffer: Buffer): Promise<ImageMetadata | null> {
+  return readImageMetadataFromHeader(buffer);
+}
+
+async function assertImagePixelLimit(buffer: Buffer): Promise<void> {
+  const meta = await readImageMetadataForLimit(buffer);
+  if (!meta) {
+    if (prefersSips()) {
+      throw new Error("Unable to determine image dimensions; refusing to process");
+    }
+    return;
+  }
+  validateImagePixelLimit(meta);
+}
+
+/**
+ * Reads EXIF orientation from JPEG buffer.
+ * Returns orientation value 1-8, or null if not found/not JPEG.
+ *
+ * EXIF orientation values:
+ * 1 = Normal, 2 = Flip H, 3 = Rotate 180, 4 = Flip V,
+ * 5 = Rotate 270 CW + Flip H, 6 = Rotate 90 CW, 7 = Rotate 90 CW + Flip H, 8 = Rotate 270 CW
+ */
+function readJpegExifOrientation(buffer: Buffer): number | null {
+  // Check JPEG magic bytes
+  if (buffer.length < 2 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return null;
+  }
+
+  let offset = 2;
+  while (offset < buffer.length - 4) {
+    // Look for marker
+    if (buffer[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+
+    const marker = buffer[offset + 1];
+    // Skip padding FF bytes
+    if (marker === 0xff) {
+      offset++;
+      continue;
+    }
+
+    // APP1 marker (EXIF)
+    if (marker === 0xe1) {
+      const exifStart = offset + 4;
+
+      // Check for "Exif\0\0" header
+      if (
+        buffer.length > exifStart + 6 &&
+        buffer.toString("ascii", exifStart, exifStart + 4) === "Exif" &&
+        buffer[exifStart + 4] === 0 &&
+        buffer[exifStart + 5] === 0
+      ) {
+        const tiffStart = exifStart + 6;
+        if (buffer.length < tiffStart + 8) {
+          return null;
+        }
+
+        // Check byte order (II = little-endian, MM = big-endian)
+        const byteOrder = buffer.toString("ascii", tiffStart, tiffStart + 2);
+        const isLittleEndian = byteOrder === "II";
+
+        const readU16 = (pos: number) =>
+          isLittleEndian ? buffer.readUInt16LE(pos) : buffer.readUInt16BE(pos);
+        const readU32 = (pos: number) =>
+          isLittleEndian ? buffer.readUInt32LE(pos) : buffer.readUInt32BE(pos);
+
+        // Read IFD0 offset
+        const ifd0Offset = readU32(tiffStart + 4);
+        const ifd0Start = tiffStart + ifd0Offset;
+        if (buffer.length < ifd0Start + 2) {
+          return null;
+        }
+
+        const numEntries = readU16(ifd0Start);
+        for (let i = 0; i < numEntries; i++) {
+          const entryOffset = ifd0Start + 2 + i * 12;
+          if (buffer.length < entryOffset + 12) {
+            break;
+          }
+
+          const tag = readU16(entryOffset);
+          // Orientation tag = 0x0112
+          if (tag === 0x0112) {
+            const value = readU16(entryOffset + 8);
+            return value >= 1 && value <= 8 ? value : null;
+          }
+        }
+      }
+      return null;
+    }
+
+    // Skip other segments
+    if (marker >= 0xe0 && marker <= 0xef) {
+      const segmentLength = buffer.readUInt16BE(offset + 2);
+      offset += 2 + segmentLength;
+      continue;
+    }
+
+    // SOF, SOS, or other marker - stop searching
+    if (marker === 0xc0 || marker === 0xda) {
+      break;
+    }
+
+    offset++;
+  }
+
+  return null;
+}
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-img-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function sipsMetadataFromBuffer(buffer: Buffer): Promise<ImageMetadata | null> {
+  return await withTempDir(async (dir) => {
+    const input = path.join(dir, "in.img");
+    await fs.writeFile(input, buffer);
+    const { stdout } = await runExec(
+      "/usr/bin/sips",
+      ["-g", "pixelWidth", "-g", "pixelHeight", input],
+      {
+        timeoutMs: 10_000,
+        maxBuffer: 512 * 1024,
+      },
+    );
+    const w = stdout.match(/pixelWidth:\s*([0-9]+)/);
+    const h = stdout.match(/pixelHeight:\s*([0-9]+)/);
+    if (!w?.[1] || !h?.[1]) {
+      return null;
+    }
+    const width = Number.parseInt(w[1], 10);
+    const height = Number.parseInt(h[1], 10);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      return null;
+    }
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+    return { width, height };
+  });
+}
+
+async function sipsResizeToJpeg(params: {
+  buffer: Buffer;
+  maxSide: number;
+  quality: number;
+}): Promise<Buffer> {
+  return await withTempDir(async (dir) => {
+    const input = path.join(dir, "in.img");
+    const output = path.join(dir, "out.jpg");
+    await fs.writeFile(input, params.buffer);
+    await runExec(
+      "/usr/bin/sips",
+      [
+        "-Z",
+        String(Math.max(1, Math.round(params.maxSide))),
+        "-s",
+        "format",
+        "jpeg",
+        "-s",
+        "formatOptions",
+        String(Math.max(1, Math.min(100, Math.round(params.quality)))),
+        input,
+        "--out",
+        output,
+      ],
+      { timeoutMs: 20_000, maxBuffer: 1024 * 1024 },
+    );
+    return await fs.readFile(output);
+  });
+}
+
+async function sipsConvertToJpeg(buffer: Buffer): Promise<Buffer> {
+  return await withTempDir(async (dir) => {
+    const input = path.join(dir, "in.heic");
+    const output = path.join(dir, "out.jpg");
+    await fs.writeFile(input, buffer);
+    await runExec("/usr/bin/sips", ["-s", "format", "jpeg", input, "--out", output], {
+      timeoutMs: 20_000,
+      maxBuffer: 1024 * 1024,
+    });
+    return await fs.readFile(output);
+  });
+}
+
+export async function getImageMetadata(buffer: Buffer): Promise<ImageMetadata | null> {
+  const metadataForLimit = await readImageMetadataForLimit(buffer).catch(() => null);
+  if (metadataForLimit) {
+    try {
+      return validateImagePixelLimit(metadataForLimit);
+    } catch (err) {
+      log.debug(`validateImagePixelLimit failed: ${err}`);
+      return null;
+    }
+  }
+
+  if (prefersSips()) {
+    return await sipsMetadataFromBuffer(buffer).catch(() => null);
+  }
+
+  try {
+    const sharp = await loadSharp();
+    const meta = await sharp(buffer).metadata();
+    const width = meta.width ?? 0;
+    const height = meta.height ?? 0;
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      return null;
+    }
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+    return validateImagePixelLimit({ width, height });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Applies rotation/flip to image buffer using sips based on EXIF orientation.
+ */
+async function sipsApplyOrientation(buffer: Buffer, orientation: number): Promise<Buffer> {
+  // Map EXIF orientation to sips operations
+  // sips -r rotates clockwise, -f flips (horizontal/vertical)
+  const ops: string[] = [];
+  switch (orientation) {
+    case 2: // Flip horizontal
+      ops.push("-f", "horizontal");
+      break;
+    case 3: // Rotate 180
+      ops.push("-r", "180");
+      break;
+    case 4: // Flip vertical
+      ops.push("-f", "vertical");
+      break;
+    case 5: // Rotate 270 CW + flip horizontal
+      ops.push("-r", "270", "-f", "horizontal");
+      break;
+    case 6: // Rotate 90 CW
+      ops.push("-r", "90");
+      break;
+    case 7: // Rotate 90 CW + flip horizontal
+      ops.push("-r", "90", "-f", "horizontal");
+      break;
+    case 8: // Rotate 270 CW
+      ops.push("-r", "270");
+      break;
+    default:
+      // Orientation 1 or unknown - no change needed
+      return buffer;
+  }
+
+  return await withTempDir(async (dir) => {
+    const input = path.join(dir, "in.jpg");
+    const output = path.join(dir, "out.jpg");
+    await fs.writeFile(input, buffer);
+    await runExec("/usr/bin/sips", [...ops, input, "--out", output], {
+      timeoutMs: 20_000,
+      maxBuffer: 1024 * 1024,
+    });
+    return await fs.readFile(output);
+  });
+}
+
+/**
+ * Normalizes EXIF orientation in an image buffer.
+ * Returns the buffer with correct pixel orientation (rotated if needed).
+ * Falls back to original buffer if normalization fails.
+ */
+export async function normalizeExifOrientation(buffer: Buffer): Promise<Buffer> {
+  await assertImagePixelLimit(buffer);
+
+  if (prefersSips()) {
+    try {
+      const orientation = readJpegExifOrientation(buffer);
+      if (!orientation || orientation === 1) {
+        return buffer; // No rotation needed
+      }
+      return await sipsApplyOrientation(buffer, orientation);
+    } catch {
+      return buffer;
+    }
+  }
+
+  try {
+    const sharp = await loadSharp();
+    // .rotate() with no args auto-rotates based on EXIF orientation
+    return await sharp(buffer).rotate().toBuffer();
+  } catch {
+    // Sharp not available or failed - return original buffer
+    return buffer;
+  }
+}
+
+export async function resizeToJpeg(params: {
+  buffer: Buffer;
+  maxSide: number;
+  quality: number;
+  withoutEnlargement?: boolean;
+}): Promise<Buffer> {
+  await assertImagePixelLimit(params.buffer);
+
+  if (prefersSips()) {
+    // Normalize EXIF orientation BEFORE resizing (sips resize doesn't auto-rotate)
+    const normalized = await normalizeExifOrientationSips(params.buffer);
+
+    // Avoid enlarging by checking dimensions first (sips has no withoutEnlargement flag).
+    if (params.withoutEnlargement !== false) {
+      const meta = await getImageMetadata(normalized);
+      if (meta) {
+        const maxDim = Math.max(meta.width, meta.height);
+        if (maxDim > 0 && maxDim <= params.maxSide) {
+          return await sipsResizeToJpeg({
+            buffer: normalized,
+            maxSide: maxDim,
+            quality: params.quality,
+          });
+        }
+      }
+    }
+    return await sipsResizeToJpeg({
+      buffer: normalized,
+      maxSide: params.maxSide,
+      quality: params.quality,
+    });
+  }
+
+  const sharp = await loadSharp();
+  // Use .rotate() BEFORE .resize() to auto-rotate based on EXIF orientation
+  return await sharp(params.buffer)
+    .rotate() // Auto-rotate based on EXIF before resizing
+    .resize({
+      width: params.maxSide,
+      height: params.maxSide,
+      fit: "inside",
+      withoutEnlargement: params.withoutEnlargement !== false,
+    })
+    .jpeg({ quality: params.quality, mozjpeg: true })
+    .toBuffer();
+}
+
+export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
+  await assertImagePixelLimit(buffer);
+
+  if (prefersSips()) {
+    return await sipsConvertToJpeg(buffer);
+  }
+  const sharp = await loadSharp();
+  return await sharp(buffer).jpeg({ quality: 90, mozjpeg: true }).toBuffer();
+}
+
+/**
+ * Checks if an image has an alpha channel (transparency).
+ * Returns true if the image has alpha, false otherwise.
+ */
+export async function hasAlphaChannel(buffer: Buffer): Promise<boolean> {
+  await assertImagePixelLimit(buffer);
+
+  try {
+    const sharp = await loadSharp();
+    const meta = await sharp(buffer).metadata();
+    // Check if the image has an alpha channel
+    // PNG color types with alpha: 4 (grayscale+alpha), 6 (RGBA)
+    // Sharp reports this via 'channels' (4 = RGBA) or 'hasAlpha'
+    return meta.hasAlpha || meta.channels === 4;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resizes an image to PNG format, preserving alpha channel (transparency).
+ * Falls back to sharp only (no sips fallback for PNG with alpha).
+ */
+export async function resizeToPng(params: {
+  buffer: Buffer;
+  maxSide: number;
+  compressionLevel?: number;
+  withoutEnlargement?: boolean;
+}): Promise<Buffer> {
+  await assertImagePixelLimit(params.buffer);
+
+  const sharp = await loadSharp();
+  // Compression level 6 is a good balance (0=fastest, 9=smallest)
+  const compressionLevel = params.compressionLevel ?? 6;
+
+  return await sharp(params.buffer)
+    .rotate() // Auto-rotate based on EXIF if present
+    .resize({
+      width: params.maxSide,
+      height: params.maxSide,
+      fit: "inside",
+      withoutEnlargement: params.withoutEnlargement !== false,
+    })
+    .png({ compressionLevel })
+    .toBuffer();
+}
+
+export async function optimizeImageToPng(
+  buffer: Buffer,
+  maxBytes: number,
+): Promise<{
+  buffer: Buffer;
+  optimizedSize: number;
+  resizeSide: number;
+  compressionLevel: number;
+}> {
+  // Try a grid of sizes/compression levels until under the limit.
+  // PNG uses compression levels 0-9 (higher = smaller but slower).
+  const sides = [2048, 1536, 1280, 1024, 800];
+  const compressionLevels = [6, 7, 8, 9];
+  let smallest: {
+    buffer: Buffer;
+    size: number;
+    resizeSide: number;
+    compressionLevel: number;
+  } | null = null;
+
+  for (const side of sides) {
+    for (const compressionLevel of compressionLevels) {
+      try {
+        const out = await resizeToPng({
+          buffer,
+          maxSide: side,
+          compressionLevel,
+          withoutEnlargement: true,
+        });
+        const size = out.length;
+        if (!smallest || size < smallest.size) {
+          smallest = { buffer: out, size, resizeSide: side, compressionLevel };
+        }
+        if (size <= maxBytes) {
+          return {
+            buffer: out,
+            optimizedSize: size,
+            resizeSide: side,
+            compressionLevel,
+          };
+        }
+      } catch {
+        // Continue trying other size/compression combinations.
+      }
+    }
+  }
+
+  if (smallest) {
+    return {
+      buffer: smallest.buffer,
+      optimizedSize: smallest.size,
+      resizeSide: smallest.resizeSide,
+      compressionLevel: smallest.compressionLevel,
+    };
+  }
+
+  throw new Error("Failed to optimize PNG image");
+}
+
+/**
+ * Internal sips-only EXIF normalization (no sharp fallback).
+ * Used by resizeToJpeg to normalize before sips resize.
+ */
+async function normalizeExifOrientationSips(buffer: Buffer): Promise<Buffer> {
+  try {
+    const orientation = readJpegExifOrientation(buffer);
+    if (!orientation || orientation === 1) {
+      return buffer;
+    }
+    return await sipsApplyOrientation(buffer, orientation);
+  } catch {
+    return buffer;
+  }
+}


### PR DESCRIPTION
## Summary

4 production-quality fixes that replace silent failures with debug/warn logging:

### Files changed

| File | Fix |
|------|-----|
| `src/hooks/gmail-watcher.ts` | Save `restartTimer` reference, `clearTimeout` on shutdown — prevents orphaned timers accumulating when gog process repeatedly crashes/restarts |
| `src/channels/bundled-channel-catalog-read.ts` | Log `warn` when channel catalog JSON fails to parse — helps debug startup failures |
| `src/media/image-ops.ts` | Log `debug` when image pixel validation fails — explains why some image uploads are silently rejected |
| `src/media/fetch.ts` | Log `debug` for first 2 fetch retry failures — makes network debugging tractable |

### Why

These are not critical failures, but unexplained `null` returns or silent retries make production debugging very difficult. The log level is `debug` (not `error`) so normal operation stays clean.

Closes openclaw/openclaw (upstream issue: silent error handling in production paths)